### PR TITLE
Update image to use openjdk-11 and pulling upstream prestosql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM openjdk:11.0.7-jre-slim-buster
 
 # Build arg expected, what version of presto are we building? (Presto's .tar.gz files extract to a versioned folder, we need to know what it's named)
 ARG BUILD_VERSION
@@ -7,20 +7,30 @@ ENV PRESTO_VERSION presto-server-${BUILD_VERSION}
 ENV GOPATH /usr/local/go
 RUN mkdir -p ${GOPATH}
 
-ADD ${PRESTO_VERSION}.tar.gz /opt/presto/
 ADD container_init.sh /container_init.sh
-RUN ln -s /opt/presto/${PRESTO_VERSION} /opt/presto/latest && \
-	chmod +x /container_init.sh && \
-	mkdir -p /opt/presto/conf/catalog && \
-	mkdir -p /var/lib/presto/data && \
-	rm -rf /opt/presto/latest/etc && \
-	ln -s /opt/presto/conf /opt/presto/latest/etc
+RUN apt update && \
+    apt install -y curl && \
+    mkdir -p /opt/presto && \
+    curl -L "https://repo1.maven.org/maven2/io/prestosql/presto-server/${BUILD_VERSION}/${PRESTO_VERSION}.tar.gz" -o "/opt/presto/${PRESTO_VERSION}.tar.gz" && \
+    tar -xzvf "/opt/presto/${PRESTO_VERSION}.tar.gz" -C /opt/presto/ && \
+    ln -s /opt/presto/${PRESTO_VERSION} /opt/presto/latest && \
+    chmod +x /container_init.sh && \
+    mkdir -p /opt/presto/conf/catalog && \
+    mkdir -p /var/lib/presto/data && \
+    rm -rf /opt/presto/latest/etc && \
+    ln -s /opt/presto/conf /opt/presto/latest/etc
 
 #\ && (cd /opt/presto && tar xvf ${PRESTO_VERSION}.tar.gz)
 
 # Fsconsul for making files from consul k/v - use consul 1.0.0 since 'master' is broken somehow in consul's go libs. Fsconsul should use godep/govendor :(
-RUN apt-get update && apt-get install -y golang-go git-core uuid python
-RUN go get -d github.com/Cimpress-MCP/fsconsul && (cd ${GOPATH}/src/github.com/hashicorp/consul && git checkout v1.0.0) && go install github.com/Cimpress-MCP/fsconsul
+RUN apt update && \
+    apt install -y golang-1.11-go git-core uuid python && \
+    ln -s /usr/lib/go-1.11/bin/go /usr/bin/go
+RUN go get -d github.com/Cimpress-MCP/fsconsul && \
+    (cd ${GOPATH}/src/github.com/hashicorp/consul && git checkout v1.0.0) && \
+    go install github.com/Cimpress-MCP/fsconsul && \
+    apt clean all && \
+    rm -rf /var/log/apt/* /var/log/alternatives.log /var/log/bootstrap.log /var/log/dpkg.log
 
 # Run the init script to start fsconsul and presto after
 CMD /container_init.sh


### PR DESCRIPTION
```
$ docker build --build-arg BUILD_VERSION=333 -t prestosql:333 .
...
$ docker run --rm prestosql:333
HOSTNAME=ed7fe539f50d
JAVA_HOME=/usr/local/openjdk-11
JAVA_BASE_URL=https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.7%2B10/OpenJDK11U-jre_
PRESTO_VERSION=presto-server-333
PWD=/
JAVA_URL_VERSION=11.0.7_10
HOME=/root
LANG=C.UTF-8
SHLVL=1
PATH=/usr/local/openjdk-11/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
GOPATH=/usr/local/go
JAVA_VERSION=11.0.7
_=/usr/bin/env
Fri May 22 23:08:11 UTC 2020 | [INFO] Starting Presto as a worker w/ 31744 MB heap. Looking in /config/presto for all related K/V...
time="2020-05-22T23:08:11Z" level=info msg="fsconsul initializing..."
time="2020-05-22T23:08:11Z" level=debug msg="Got mapping config" config="&{[]  /config/presto/catalog/ /opt/presto/conf/catalog/ }"
time="2020-05-22T23:08:14Z" level=debug msg="Failure from watch function" error="Get http://172.17.42.1:8500/v1/kv/config/presto/catalog/?recurse=: dial tcp 172.17.42.1:8500: connect: no route to host"
time="2020-05-22T23:08:14Z" level=debug msg=0
time="2020-05-22T23:08:14Z" level=info msg="fsconsul initializing..."
time="2020-05-22T23:08:14Z" level=debug msg="Got mapping config" config="&{[]  /config/presto/worker /opt/presto/conf/ }"
time="2020-05-22T23:08:17Z" level=debug msg="Failure from watch function" error="Get http://172.17.42.1:8500/v1/kv/config/presto/worker?recurse=: dial tcp 172.17.42.1:8500: connect: no route to host"
time="2020-05-22T23:08:17Z" level=debug msg=0
ERROR: Config file is missing: /opt/presto/conf/config.properties
```